### PR TITLE
Remove ase.Atoms dependence of SphericalExpansion by Structure object

### DIFF
--- a/tests/test_spherical_expansions.py
+++ b/tests/test_spherical_expansions.py
@@ -24,14 +24,16 @@ class TestSphericalExpansion:
         vector_expansion = VectorExpansion(self.hypers, device="cpu")
         with torch.no_grad():
             tm = vector_expansion.forward(self.structures)
-        assert equistore.operations.equal(tm_ref, tm)
+        # default types are float32 so we set accuracy to 1e-7
+        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)
 
     def test_spherical_expansion_coeffs(self):
         tm_ref = equistore.core.io.load_custom_array("tests/data/spherical_expansion_coeffs-ethanol1_0-data.npz", equistore.core.io.create_torch_array)
         spherical_expansion_calculator = SphericalExpansion(self.hypers, self.all_species)
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(self.structures)
-        assert equistore.operations.equal(tm_ref, tm)
+        # default types are float32 so we set accuracy to 1e-7
+        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)
 
     def test_spherical_expansion_coeffs_alchemical(self):
         with open("tests/data/expansion_coeffs-ethanol1_0-alchemical-hypers.json", "r") as f:
@@ -41,5 +43,5 @@ class TestSphericalExpansion:
         spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species)
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(self.structures)
-        assert equistore.operations.equal(tm_ref, tm)
-
+        # default types are float32 so we set accuracy to 1e-7
+        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)

--- a/tests/test_spherical_expansions.py
+++ b/tests/test_spherical_expansions.py
@@ -9,13 +9,13 @@ import numpy as np
 import ase.io
 
 from torch_spex.spherical_expansions import VectorExpansion, SphericalExpansion
-from torch_spex.structures import Structures
+from torch_spex.structures import ase_atoms_to_tensordict
 
 class TestSphericalExpansion:
     device = "cpu"
     frames = ase.io.read('datasets/rmd17/ethanol1.extxyz', ':1')
     all_species = np.unique(np.hstack([frame.numbers for frame in frames]))
-    structures = Structures(frames)
+    structures = ase_atoms_to_tensordict(frames)
     with open("tests/data/expansion_coeffs-ethanol1_0-hypers.json", "r") as f:
         hypers = json.load(f)
 

--- a/torch_spex/spherical_expansions.py
+++ b/torch_spex/spherical_expansions.py
@@ -10,7 +10,6 @@ from equistore import TensorMap, Labels, TensorBlock
 from .angular_basis import AngularBasis
 from .radial_basis import RadialBasis
 
-from .structures import Structures
 from typing import Dict, List
 
 class SphericalExpansion(torch.nn.Module):
@@ -52,7 +51,7 @@ class SphericalExpansion(torch.nn.Module):
 
     >>> import numpy as np
     >>> from ase.build import molecule
-    >>> from torch_spex.structures import Structures
+    >>> from torch_spex.structures import ase_atoms_to_tensordict
     >>> from torch_spex.spherical_expansions import SphericalExpansion
     >>> hypers = {
     ...     "cutoff radius": 3,
@@ -63,7 +62,8 @@ class SphericalExpansion(torch.nn.Module):
     ... }
     >>> h2o = molecule("H2O")
     >>> spherical_expansion = SphericalExpansion(hypers, [1,8], device="cpu")
-    >>> spherical_expansion.forward(Structures([h2o]))
+    >>> atomic_structures = ase_atoms_to_tensordict([h2o])
+    >>> spherical_expansion.forward(atomic_structures)
     TensorMap with 2 blocks
     keys: ['a_i' 'lam' 'sigma']
              1     0      1
@@ -89,7 +89,7 @@ class SphericalExpansion(torch.nn.Module):
         else:
             self.is_alchemical = False
 
-    def forward(self, structures: Structures):
+    def forward(self, structures: Dict[str, torch.Tensor]):
 
         expanded_vectors = self.vector_expansion_calculator(structures)
         samples_metadata = expanded_vectors.block(l=0).samples
@@ -233,7 +233,7 @@ class VectorExpansion(torch.nn.Module):
         self.l_max = self.radial_basis_calculator.l_max
         self.spherical_harmonics_calculator = AngularBasis(self.l_max)
 
-    def forward(self, structures: Structures):
+    def forward(self, structures: Dict[str, torch.Tensor]):
 
         cutoff_radius = self.hypers["cutoff radius"]
         cartesian_vectors = get_cartesian_vectors(structures, cutoff_radius)
@@ -280,24 +280,25 @@ class VectorExpansion(torch.nn.Module):
         return vector_expansion_tmap
 
 
-def get_cartesian_vectors(structures, cutoff_radius):
+def get_cartesian_vectors(structures: Dict[str, torch.Tensor], cutoff_radius: float):
 
     labels = []
     vectors = []
 
-    for structure_index in range(structures.n_structures):
+    for structure_index in range(structures["n_structures"]):
 
-        where_selected_structure = np.where(structures.structure_indices == structure_index)[0]
+        where_selected_structure = np.where(structures["structure_indices"] == structure_index)[0]
 
         centers, neighbors, unit_cell_shift_vectors = get_neighbor_list(
-            structures.positions.detach().cpu().numpy()[where_selected_structure], 
-            structures.pbcs[structure_index], 
-            structures.cells[structure_index], 
+            structures["positions"].detach().cpu().numpy()[where_selected_structure], 
+            structures["pbcs"][structure_index], 
+            structures["cells"][structure_index], 
             cutoff_radius) 
         
-        positions = structures.positions[torch.LongTensor(where_selected_structure)]
-        cell = torch.tensor(np.array(structures.cells[structure_index]), dtype=torch.get_default_dtype())
-        species = structures.atomic_species[structure_index]
+        atoms_idx = torch.LongTensor(where_selected_structure)
+        positions = structures["positions"][atoms_idx]
+        cell = torch.tensor(np.array(structures["cells"][structure_index]), dtype=torch.get_default_dtype())
+        species = structures["atomic_species"][atoms_idx]
 
         structure_vectors = positions[neighbors] - positions[centers] + (unit_cell_shift_vectors @ cell).to(positions.device)  # Warning: it works but in a weird way when there is no cell
         vectors.append(structure_vectors)


### PR DESCRIPTION
* replace Structure class with a Dict[str, torch.Tensor] because torch
  does not support non torch Tensor types for tracing
* the conversion from ase.Atoms to Dict[str, torch.Tensor]  is done within a function
   because TorchScript does not support foreign types
* add typing for various inputs